### PR TITLE
feat: Add National Archives to Great Britain

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Finding aids for textual and multimedia [primary sources](https://en.wikipedia.o
 ### Great Britain
 
 - [The Proceedings of the Old Bailey](https://www.oldbaileyonline.org/) - London's Central Criminal Court, 1674 to 1913.
+- [](https://www.nationalarchives.gov.uk/) - A non-ministerial department, and the official archive and publisher for the UK Government, and for England and Wales. 
 - [NLS](https://data.nls.uk/data/) - Data collections from the National Library of Scotland.
 
 ### Netherlands

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Finding aids for textual and multimedia [primary sources](https://en.wikipedia.o
 ### Great Britain
 
 - [The Proceedings of the Old Bailey](https://www.oldbaileyonline.org/) - London's Central Criminal Court, 1674 to 1913.
-- [](https://www.nationalarchives.gov.uk/) - A non-ministerial department, and the official archive and publisher for the UK Government, and for England and Wales. 
+- [National Archives](https://www.nationalarchives.gov.uk/) - A non-ministerial department, and the official archive and publisher for the UK Government, and for England and Wales. 
 - [NLS](https://data.nls.uk/data/) - Data collections from the National Library of Scotland.
 
 ### Netherlands

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Finding aids for textual and multimedia [primary sources](https://en.wikipedia.o
 ### Great Britain
 
 - [The Proceedings of the Old Bailey](https://www.oldbaileyonline.org/) - London's Central Criminal Court, 1674 to 1913.
-- [National Archives](https://www.nationalarchives.gov.uk/) - A non-ministerial department, and the official archive and publisher for the UK Government, and for England and Wales. 
+- [The National Archives](https://www.nationalarchives.gov.uk/) - A non-ministerial department, and the official archive and publisher for the UK Government, and for England and Wales. 
 - [NLS](https://data.nls.uk/data/) - Data collections from the National Library of Scotland.
 
 ### Netherlands


### PR DESCRIPTION
Add / Remove / Edit {entry name} to/from the "{section name}" section.

**Short pitch**

This change will add the national archives to the Great Britain Section. This should be added as it is the official archive and publisher for the UK Government, and for England and Wales, meaning that any UK government archives could be found here. There is also a ton of research areas and guides listed to help with further research: https://www.nationalarchives.gov.uk/help-with-your-research/#find-a-research-guide 

## Checklist

- [x] I have read and understood the [contribution guidelines](https://github.com/writing-resources/awesome-scientific-writing/blob/main/CONTRIBUTING.md).
- [x] Table of contents has been updated (if a section is added / removed).
- [x] Contents have been sorted alphabetically.

<!-- NOTE: Please do not skip the template -->
