### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"test:unit": "vitest",
 		"lint": "prettier --plugin-search-dir . --check . '!{CODE_OF_CONDUCT.md,LICENSE.md}' && eslint .",
 		"format": "prettier --plugin-search-dir . --write .",
-		"prepare": "node utils/sortJSON.js && node utils/compileReadme.js && node utils/getData.js && npm run format",
+		"prepare": "node utils/sortJSON.js && node --experimental-json-modules utils/compileReadme.js && node utils/getData.js && npm run format",
 		"awesome-lint": "awesome-lint"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Add experimental-flag to node call (compatability reasons)

I was opening the repo in [Stackblitz](https://stackblitz.com/github/maehr/awesome-digital-history/tree/sveltekit) and got an error, because Stackblitz doesn't use the newest node version. It's because there is a dynamic inport of JSON data in a js file. I added the flag so it works with earlier node versions aswell.
