### PR TITLE
Fix default entry structure in sortJSON

### DIFF
--- a/utils/sortJSON.js
+++ b/utils/sortJSON.js
@@ -11,27 +11,27 @@ fs.readFile(filepath, 'utf-8', (err, data) => {
 	try {
 		const jsonData = JSON.parse(data);
 
-		// Ensure all entries have the required structure
-		jsonData.forEach((entry) => {
-			const defaultStructure = {
-				title: '',
-				description: '',
-				url: '',
-				region: [],
-				language: [],
-				type: [],
-				period: []
-			};
+               // Ensure all entries have the required structure
+               const updatedData = jsonData.map((entry) => {
+                       const defaultStructure = {
+                               title: '',
+                               description: '',
+                               url: '',
+                               region: [],
+                               language: [],
+                               type: [],
+                               period: []
+                       };
 
-			return { ...defaultStructure, ...entry };
-		});
+                       return { ...defaultStructure, ...entry };
+               });
 
-		// Sort the JSON array by the "title" field
-		jsonData.sort((a, b) => a.title.localeCompare(b.title));
+               // Sort the JSON array by the "title" field
+               updatedData.sort((a, b) => a.title.localeCompare(b.title));
 
 		// Write the sorted and amended JSON data back to the file
 		try {
-			const jsonString = JSON.stringify(jsonData, null, 2);
+                       const jsonString = JSON.stringify(updatedData, null, 2);
 			fs.writeFile(filepath, jsonString, (err) => {
 				if (err) {
 					console.error(`Error writing file: ${err.message}`);


### PR DESCRIPTION
## Summary
- fix bug in sortJSON.js that didn't apply defaults

## Testing
- `npm run test:unit`
- `npm test` *(fails: Process from config.webServer was not able to start)*

------
https://chatgpt.com/codex/tasks/task_e_683ff6740d308331b2bf8ef37cc8494e