### PR TITLE
Add interactive historical decision simulators to Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Finding aids for textual and multimedia [primary sources](https://en.wikipedia.o
 - [The CTP Book](https://comp-think.github.io/) - A book for teaching Computational Thinking and Programming skills to people with a background in the Humanities.
 - [The Programming Historian](https://programminghistorian.org/) - Novice-friendly, peer-reviewed tutorials that help humanists learn a wide range of digital tools, techniques, and workflows to facilitate research and teaching.
 - [UCI Digital History](https://guides.lib.uci.edu/history/history_dh) - Overview on the field of Digital History and Digital Humanities.
+- [Historical Decision Simulators](https://ordinarymantrying.com/tools/) - Browser-based interactive simulations presenting pivotal decisions from Gandhi, Lincoln, Mandela, Marie Curie, and 8 other historical figures. You make each decision blind, then see what they actually chose and why. 12 figures, 84 decisions. Free, no login.
 
 ## More Awesome
 


### PR DESCRIPTION
## What's added

Under **Learning**:

- **[Historical Decision Simulators](https://ordinarymantrying.com/tools/)** — Browser-based interactive simulations presenting pivotal decisions from Gandhi, Lincoln, Mandela, Marie Curie, Steve Jobs, Elon Musk, Warren Buffett, Walt Disney, Soichiro Honda, J.K. Rowling, Stephen Hawking, and Zhang Xue. You make each decision blind — without knowing what they chose — then see their actual decision and the historical reasoning behind it. 12 figures, 84 decisions total. Free, no login, no installation.

These fit the repo's mission of "learn how to research history digitally" — specifically the format of presenting historical agents facing their actual documented choices, which is a recognized method in historical education (counterfactual reasoning, decision-point analysis).

Individual simulators:
- [Gandhi Simulator](https://ordinarymantrying.com/tools/gandhi-simulator.html) — 7 decisions 1906–1948
- [Lincoln Simulator](https://ordinarymantrying.com/tools/lincoln-simulator.html) — 7 decisions 1858–1865
- [Mandela Simulator](https://ordinarymantrying.com/tools/mandela-simulator.html) — 7 decisions 1964–1994

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Historical Decision Simulators" as a new resource to the learning materials section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->