### PR TITLE
Add Historical Decision Simulators to Learning resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Finding aids for textual and multimedia [primary sources](https://en.wikipedia.o
 - [The CTP Book](https://comp-think.github.io/) - A book for teaching Computational Thinking and Programming skills to people with a background in the Humanities.
 - [The Programming Historian](https://programminghistorian.org/) - Novice-friendly, peer-reviewed tutorials that help humanists learn a wide range of digital tools, techniques, and workflows to facilitate research and teaching.
 - [UCI Digital History](https://guides.lib.uci.edu/history/history_dh) - Overview on the field of Digital History and Digital Humanities.
-- [Historical Decision Simulators](https://ordinarymantrying.com/tools/) - Browser-based interactive simulations presenting pivotal decisions from Gandhi, Lincoln, Mandela, Marie Curie, and 8 other historical figures. You make each decision blind, then see what they actually chose and why. 12 figures, 84 decisions. Free, no login.
+- [Historical Decision Simulators](https://ordinarymantrying.com/tools/) - Browser-based interactive simulations presenting pivotal decisions from Mandela, Marie Curie, Warren Buffett, Steve Jobs, Elon Musk, and 6 other historical figures. You make each decision blind, then see what they actually chose and why. 11 figures, 77 decisions. Free, no login.
 
 ## More Awesome
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Finding aids for textual and multimedia [primary sources](https://en.wikipedia.o
 - [The CTP Book](https://comp-think.github.io/) - A book for teaching Computational Thinking and Programming skills to people with a background in the Humanities.
 - [The Programming Historian](https://programminghistorian.org/) - Novice-friendly, peer-reviewed tutorials that help humanists learn a wide range of digital tools, techniques, and workflows to facilitate research and teaching.
 - [UCI Digital History](https://guides.lib.uci.edu/history/history_dh) - Overview on the field of Digital History and Digital Humanities.
+- [Historical Decision Simulators](https://ordinarymantrying.com/tools/) - Browser-based interactive simulations presenting pivotal decisions from Gandhi, Lincoln, Mandela, Marie Curie, and 8 other historical figures. You make each decision blind, then see what they actually chose and why. 12 figures, 84 decisions. Free, no login.
 
 ## More Awesome
 


### PR DESCRIPTION
## What's added

Under **Learning** (Network Analysis section):

- **[Historical Decision Simulators](https://ordinarymantrying.com/tools/)** — Browser-based interactive simulations presenting pivotal decisions from Mandela, Marie Curie, Warren Buffett, Steve Jobs, Elon Musk, and 6 other historical figures. You make each decision blind — without knowing what they chose — then see their actual decision and the historical reasoning behind it. 11 figures, 77 decisions total. Free, no login, no installation.

**All 11 figures:** Walt Disney, Soichiro Honda, Marie Curie, Steve Jobs, J.K. Rowling, Oprah Winfrey, Elon Musk, Nelson Mandela, Warren Buffett, Stephen Hawking, Zhang Xue.

Each simulator: 7 documented decisions → user chooses blind → historical outcome revealed with context.

These fit the repo's mission of "learn how to research history digitally" via counterfactual reasoning and decision-point analysis with actual documented historical choices.

---
*Previous PR #352 was closed due to inaccurate figure/decision counts. This PR corrects those errors.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Historical Decision Simulators” resource to the learning materials list, including a link and short description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->