### PR TITLE
fix(entries): update RunoVerse description to the project's own framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Finding aids for textual and multimedia [primary sources](https://en.wikipedia.o
 - [Mapire](https://mapire.eu/) - Interactive historical maps.
 - [Monasterium](https://www.monasterium.net/mom/home) - Deeds from all over Europe.
 - [Project Gutenberg](https://www.gutenberg.org/) - A library of over 60,000 free eBooks.
-- [RunoVerse](https://runoverse.org/) - Research platform for Finnish and Estonian runosong oral folk poetry with cross-lingual comparison and geographic analysis.
+- [RunoVerse](https://runoverse.org/) - Exploration toolkit for Finnic runosong (runolaulu, regilaul) across four folklore corpora, with lemma search, cross-lingual verse comparison and geographic analysis.
 - [tímarit.is](https://www.timarit.is/) - Digitized newspapers and magazines from Iceland, Greenland and the Faroe Islands.
 - [Visual Archive Southeastern Europe](http://gams.uni-graz.at/context:vase) - Historical and contemporary visual materials from Southeastern Europe.
 

--- a/entries/runoverse.qmd
+++ b/entries/runoverse.qmd
@@ -1,9 +1,9 @@
 ---
 title: RunoVerse
 slug: runoverse
-description: RunoVerse is a research platform for exploring 292'092 Finnish and Estonian runosong poems from four folklore collections, with cross-lingual tools and AI analysis.
+description: RunoVerse is a free exploration toolkit for roughly 290,000 Finnic runosong poems from four folklore collections, with lemma search, cross-lingual verse comparison, nine dictionaries and AI-assisted commentary.
 external_url: https://runoverse.org/
-short_description: Research platform for Finnish and Estonian runosong oral folk poetry with cross-lingual comparison and geographic analysis.
+short_description: Exploration toolkit for Finnic runosong (runolaulu, regilaul) across four folklore corpora, with lemma search, cross-lingual verse comparison and geographic analysis.
 directory_section: archives
 section_label: Archives and primary sources
 regions:
@@ -36,8 +36,8 @@ toc: false
 
 ## Why it matters
 
-RunoVerse provides structured digital access to 292'092 poems from four major Finnic runosong corpora: SKVR (Suomen Kansan Vanhat Runot — Finnish folk poetry), JR (Julkaisemattomat Runot — unpublished Finnish runosongs), KR (literary runosong works), and ERAB (Eesti Regilaulude Andmebaas — Estonian runosong database). Runosong is the shared oral folk poetry tradition of Finnic peoples and represents one of the largest bodies of oral poetry recorded in Europe.
+RunoVerse provides structured digital access to roughly 290,000 poems from four runosong corpora: SKVR (Suomen Kansan Vanhat Runot, the published Finnish, Karelian and Ingrian folk poetry), JR (Julkaisemattomat Runot, unpublished Finnish runosongs), KR (Kirjalliset Runot, literary runosong texts from 1658 to 1866), and ERAB (Eesti Regilaulude Andmebaas, the Estonian runosong database). Runosong (runolaulu, regilaul) is the shared oral poetry tradition of the Finnic peoples and one of the largest bodies of oral poetry recorded in Europe.
 
-The platform supports cross-lingual research between Finnish and Estonian texts through AI-assisted translations, similarity algorithms, dictionary cross-references from 9 lexicographic sources, and 70+ analytical tools including geographic analysis, semantic annotation, concordance search, and emotion analysis. The interface is in English, while source texts appear in Finnish, Estonian, and related Finnic dialects.
+The platform supports comparison across the languages and collections of the corpora through a verse-similarity engine, AI-assisted English translations, dictionary cross-references from nine lexicographic sources, and analytical tools for wordform and lemma search, concordances, collocates, alliteration, cognates, geographic analysis and emotion analysis. The interface is available in English, Estonian and Finnish; source texts appear in Finnish, Karelian, Ingrian and Estonian dialects.
 
 RunoVerse is useful for researchers in folklore studies, historical linguistics, digital humanities, and Finnic cultural heritage who need a single environment for searching, comparing, and analyzing this oral poetry tradition across language and regional boundaries.

--- a/entries/runoverse.qmd
+++ b/entries/runoverse.qmd
@@ -1,7 +1,7 @@
 ---
 title: RunoVerse
 slug: runoverse
-description: RunoVerse is a free exploration toolkit for roughly 290,000 Finnic runosong poems from four folklore collections, with lemma search, cross-lingual verse comparison, nine dictionaries and AI-assisted commentary.
+description: RunoVerse is a free exploration toolkit for roughly 290,000 Finnic runosong poems from four folklore collections, with lemma search, verse comparison and AI-assisted commentary.
 external_url: https://runoverse.org/
 short_description: Exploration toolkit for Finnic runosong (runolaulu, regilaul) across four folklore corpora, with lemma search, cross-lingual verse comparison and geographic analysis.
 directory_section: archives


### PR DESCRIPTION
## Pull Request

Change `RunoVerse` in `entries/runoverse.qmd` (and the generated `README.md` line).

**Short pitch**

The current entry describes RunoVerse as a platform for "Finnish and Estonian runosong", which understates its scope: the site covers the runosong tradition of the Finnic peoples as a whole (the Finnish, Karelian, Ingrian and Estonian material of the SKVR, JR, KR and ERAB corpora). The exact poem count in the description also drifts with each data release, so it now reads "roughly 290,000". This change brings `short_description`, `description` and the "Why it matters" text in line with the project's own self-description and current state (the interface is now available in English, Estonian and Finnish). No URL change; the entry stays in the same section with the same metadata.

### Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I am not a first-time contributor (#338 added this entry).
- [x] I checked the change against [EDITORIAL_POLICY.md](../EDITORIAL_POLICY.md).
- [ ] I ran `npm install`.
- [ ] I ran `npm run check` (not run locally; relying on CI).
- [x] I updated provenance fields where relevant (none needed; authors unchanged).
- [x] No source URL changed, so no new screenshot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated RunoVerse descriptions to present it as an exploration toolkit for Finnic runosong.
  - Documented its collection of roughly 290,000 poems across four folklore corpora.
  - Highlighted lemma search, dictionaries, AI commentary, cross-lingual verse comparison, and geographic analysis.
  - Expanded details about supported languages, interface languages, and source-text dialects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->